### PR TITLE
Adding the 'rollup' command. I'm not super happy with the route regex…

### DIFF
--- a/spec/lita/handlers/onewheel_loggly_spec.rb
+++ b/spec/lita/handlers/onewheel_loggly_spec.rb
@@ -17,6 +17,12 @@ def mock_main_logs_command
   mock_it_up('mock_next_result', 'https://lululemon.loggly.com/apiv2/events/iterate?next=9cb4b38a-37d7-43d3-ad79-063cf2d1c43c')
 end
 
+def mock_rollup_command
+  mock_main_logs_command
+  mock_it_up('mock_result', "https://lululemon.loggly.com/apiv2/events/iterate?q=fault%3Dstuffystuff&from=-10m&until=&size=1000")
+
+end
+
 describe Lita::Handlers::OnewheelLoggly, lita_handler: true do
 
   before(:each) do
@@ -57,5 +63,12 @@ describe Lita::Handlers::OnewheelLoggly, lita_handler: true do
 
     send_command 'logs 10m'
     expect(replies.last).to include('58 events (0.109%)')
+  end
+
+  it 'rolls up logs by req_url' do
+    mock_rollup_command
+
+    send_command 'rollup fault=stuffystuff 10m'# fault=endeca_yo 10m'
+    expect(replies.last).to include('Counted 23: https://shop.lululemon.com//llmapi/v1/order/additem')
   end
 end


### PR DESCRIPTION
…, it's matching on more than "rollup fault=endeca.blah 10m" (it's matching on rollup 10m/rollup/etc).